### PR TITLE
Added support for PPC64LE architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: cpp
 compiler:
   - gcc
   - clang
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Hi,

I have a slight change to enable travis build for PPC64LE architecture, request you to please review.

Thanks