### PR TITLE
test_fasta.cxx: auto type for i increment.

### DIFF
--- a/test/test_fasta.cxx
+++ b/test/test_fasta.cxx
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]){
 
 	auto base_seed = seed;
 
-	for( int i=0; i< seqs.size(); i++){
+	for( auto i=0u; i< seqs.size(); i++){
 		cout << ">S" << i << " (base_seed: " << base_seed << ")" << endl;
 		print_seq( base_seed, seed++, length, line_length, seqs[i]);
 	}


### PR DESCRIPTION
This fixes a warning caused by the difference of type signs between the original _int i_ and the apparently unsigned _seqs.size()_ in the _for_ loop termination condition.